### PR TITLE
added ability to run overall code sniffer commands, if necessary, using a repo-standard version of PHP in a docker container

### DIFF
--- a/bin/codesniffer
+++ b/bin/codesniffer
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+if [[ $# -eq 0 ]] ; then
+    echo 'This file supports composer commands, it should not be run directly.'
+    exit 0
+fi
+
+command=$1
+shift
+path="$(cd "$(dirname "$1")"; pwd)/$(basename "$1")"
+echo $path
+shift
+restofcommands=$@
+
+docker compose run --rm -u $(id -u):$(id -g) -v "$path:/var/test" php ./vendor/bin/$command -v --standard=./src/ruleset.xml ../test $restofcommands

--- a/composer.json
+++ b/composer.json
@@ -18,6 +18,11 @@
             "email": "tallen@pdga.com"
         }
     ],
+    "scripts": {
+        "sniff": "bin/codesniffer phpcs",
+        "format": "bin/codesniffer phpcbf",
+        "format-verbose": "bin/codesniffer phpcbf -v"
+    },
     "minimum-stability": "stable",
     "require": {},
     "require-dev": {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,6 @@
+services:
+  php:
+    image: php:8.2.4-cli-alpine
+    volumes:
+      - ./:/var/pdga
+    working_dir: /var/pdga


### PR DESCRIPTION
Can now: `composer run format ../php-data-objects/src` or `composer run format /Users/ha/Code/data-objects/src` etc