### PR TITLE
added check for cyclomatic complexity to the main ruleset

### DIFF
--- a/src/ruleset.xml
+++ b/src/ruleset.xml
@@ -359,5 +359,9 @@
     </rule>
 
     <!-- Custom PDGA rules -->
-
+    <rule ref="Generic.Metrics.CyclomaticComplexity">
+        <properties>
+            <property name="complexity" value="9"/>
+        </properties>
+    </rule>
 </ruleset>


### PR DESCRIPTION
https://en.wikipedia.org/wiki/Cyclomatic_complexity

<img width="980" alt="image" src="https://github.com/user-attachments/assets/02a99f95-da18-442e-8e47-098096db0b3c">

This defaults to 9, which will flag anything greater.  PHP Storm has it's own version that allows for some context actions for refactoring. This can flag for all IDEs and also for CI automation.